### PR TITLE
Sign in routing

### DIFF
--- a/src/layout/App.tsx
+++ b/src/layout/App.tsx
@@ -25,18 +25,24 @@ const App = () => {
       ),
   });
 
-  useEffect(() => {
-    if (error || !currentUser) {
-      navigate("/onboard");
-    }
-  }, [user, userData]);
-
   // if there is an airtable record id, but no user data, get the user
   useEffect(() => {
     if (userData) {
       setCurrentUser(userData as PassengerData);
     }
   }, [userData]);
+
+  useEffect(() => {
+    if (!user?.publicMetadata.airtableRecordId) {
+      navigate("/onboard");
+    }
+  }, [currentUser]);
+
+  /*useEffect(() => {
+    if (error && !currentUser) {
+      navigate("/onboard");
+    }
+  }, [user, userData]);*/
 
   return (
     <div className={styles.appContainer}>

--- a/src/layout/App.tsx
+++ b/src/layout/App.tsx
@@ -26,7 +26,7 @@ const App = () => {
   });
 
   useEffect(() => {
-    if (error && !currentUser) {
+    if (error || !currentUser) {
       navigate("/onboard");
     }
   }, [user, userData]);

--- a/src/layout/OnboardingPage/OnboardingPage.tsx
+++ b/src/layout/OnboardingPage/OnboardingPage.tsx
@@ -150,49 +150,76 @@ const OnboardingPage = () => {
               </form>
             </>
           ) : exists === "yes" ? (
-            <div className={styles.onboardingBlockHeader}>
-              {"Looks like you've flown with us before!"}
-              <p
-                className={styles.subtitleText}
-              >{`If this is not you, please contact us`}</p>
-              <Divider spacing={DividerSpacing.MEDIUM} />
-              <div>
-                <div className={styles.patientGroup}>
-                  <span className={styles.patientLabel}>First Name</span>{" "}
-                  <span className={styles.patientText}>
-                    {userData?.["First Name"]}
-                  </span>
+            userData?.["Email"] === user?.primaryEmailAddress?.emailAddress ? (
+              <div className={styles.onboardingBlockHeader}>
+                {"Looks like you've flown with us before!"}
+                <p
+                  className={styles.subtitleText}
+                >{`If this is not you, please contact us`}</p>
+                <Divider spacing={DividerSpacing.MEDIUM} />
+                <div>
+                  <div className={styles.patientGroup}>
+                    <span className={styles.patientLabel}>First Name</span>{" "}
+                    <span className={styles.patientText}>
+                      {userData?.["First Name"]}
+                    </span>
+                  </div>
+                  <div className={styles.patientGroup}>
+                    <span className={styles.patientLabel}>Last Name</span>{" "}
+                    <span className={styles.patientText}>
+                      {userData?.["Last Name"]}
+                    </span>
+                  </div>
+                  <div className={styles.patientGroup}>
+                    <span className={styles.patientLabel}>Email</span>{" "}
+                    <span className={styles.patientText}>
+                      {userData?.["Email"].replace(
+                        /^(.{3}).*@/,
+                        "$1" +
+                          "*".repeat(
+                            userData?.["Email"].split("@")[0].length - 3,
+                          ) +
+                          "@",
+                      )}
+                    </span>
+                  </div>
                 </div>
-                <div className={styles.patientGroup}>
-                  <span className={styles.patientLabel}>Last Name</span>{" "}
-                  <span className={styles.patientText}>
-                    {userData?.["Last Name"]}
-                  </span>
-                </div>
-                <div className={styles.patientGroup}>
-                  <span className={styles.patientLabel}>City</span>{" "}
-                  <span className={styles.patientText}>
-                    {userData?.["Email"].replace(
-                      /^(.{3}).*@/,
-                      "$1" +
-                        "*".repeat(
-                          userData?.["Email"].split("@")[0].length - 3,
-                        ) +
-                        "@",
-                    )}
-                  </span>
+                <div className={styles.continueButtonContainer}>
+                  <Button
+                    text="Continue to dashboard"
+                    variant={ButtonVariant.Regular}
+                    onClick={() => {
+                      linkUserMutate();
+                    }}
+                  />
                 </div>
               </div>
-              <div className={styles.continueButtonContainer}>
-                <Button
-                  text="Continue to dashboard"
-                  variant={ButtonVariant.Regular}
-                  onClick={() => {
-                    linkUserMutate();
-                  }}
-                />
+            ) : (
+              <div className={styles.onboardingBlockHeader}>
+                {"We don't recognize you!"}
+                <p className={styles.subtitleText}>
+                  The provided information matches an account with a different
+                  email address than the one currently signed in. For security
+                  reasons, you can only link an account associated with your
+                  email address.
+                </p>
+                <p className={styles.subtitleText}>
+                  If you believe this is an error, please contact support for
+                  assistance.
+                </p>
+                <Divider spacing={DividerSpacing.MEDIUM} />
+                <div className={styles.continueButtonContainer}>
+                  <Button
+                    text="Try again"
+                    variant={ButtonVariant.Regular}
+                    color={ButtonColor.Grey}
+                    onClick={() => {
+                      setExists(null);
+                    }}
+                  />
+                </div>
               </div>
-            </div>
+            )
           ) : (
             <div className={styles.onboardingBlockHeader}>
               {"We don't recognize you!"}

--- a/src/layout/OnboardingPage/OnboardingPage.tsx
+++ b/src/layout/OnboardingPage/OnboardingPage.tsx
@@ -81,8 +81,10 @@ const OnboardingPage = () => {
     mutationFn: async () =>
       linkUser(userData?.["AirTable Record ID"] || "", await getToken()),
     onSuccess: () => {
-      setCurrentUser(userData as PassengerData);
-      navigate("/dashboard");
+      user?.reload().then(() => {
+        setCurrentUser(userData as PassengerData);
+        navigate("/dashboard");
+      });
     },
     onError: () => {
       setExists("no");


### PR DESCRIPTION
Fixes:
* Redirect to /onboard from any other page if the user doesn't have an Airtable record set
* When linking to an existing account, don't allow the user to link to an account that was created under a different email address than the one currently signed in
* Linking to existing account now properly sets Airtable record id in Clerk public metadata